### PR TITLE
Allow setting a default library_path at build time

### DIFF
--- a/cvbasic.c
+++ b/cvbasic.c
@@ -25,6 +25,12 @@
 #include "cpu6502.h"
 #include "cpu9900.h"
 
+#ifdef ASM_LIBRARY_PATH
+#define DEFAULT_ASM_LIBRARY_PATH ASM_LIBRARY_PATH
+#else
+#define DEFAULT_ASM_LIBRARY_PATH ""
+#endif
+
 #define VERSION "v0.7.0 Sep/03/2024"
 
 #define TEMPORARY_ASSEMBLER "cvbasic_temporary.asm"
@@ -110,7 +116,7 @@ static struct console {
 
 static int err_code;
 
-static char library_path[4096];
+static char library_path[4096] = DEFAULT_ASM_LIBRARY_PATH;
 static char path[4096];
 
 static int last_is_return;
@@ -5436,6 +5442,9 @@ int main(int argc, char *argv[])
         fprintf(stderr, "    By default, it will generate assembler files for Colecovision.\n");
         fprintf(stderr, "    The library_path argument is optional so you can provide a\n");
         fprintf(stderr, "    path where the prologue and epilogue files are available.\n");
+#ifdef ASM_LIBRARY_PATH
+        fprintf(stderr, "    Default: '" DEFAULT_ASM_LIBRARY_PATH "'\n");
+#endif
         fprintf(stderr, "\n");
         fprintf(stderr, "    It will return a zero error code if compilation was\n");
         fprintf(stderr, "    successful, or non-zero otherwise.\n\n");
@@ -5566,14 +5575,14 @@ int main(int argc, char *argv[])
     if (c < argc) {
         strcpy(library_path, argv[c]);
         c++;
+	}
 #ifdef _WIN32
-        if (strlen(library_path) > 0 && library_path[strlen(library_path) - 1] != '\\')
-            strcat(library_path, "\\");
+	if (strlen(library_path) > 0 && library_path[strlen(library_path) - 1] != '\\')
+		strcat(library_path, "\\");
 #else
-        if (strlen(library_path) > 0 && library_path[strlen(library_path) - 1] != '/')
-            strcat(library_path, "/");
+	if (strlen(library_path) > 0 && library_path[strlen(library_path) - 1] != '/')
+		strcat(library_path, "/");
 #endif
-    }
     
     hex = '$';
     if (target == CPU_9900) {


### PR DESCRIPTION
Support passing `-DASM_LIBRARY_PATH="/some/path"` at build time to set a default `library_path` value. This is handy for packaging the program, to allow installing the provided assembler sources under e.g. `/use/share/cvbasic` and save the user from having to specify the path on every invocation.

If the preprocessor symbol is not defined, use an empty string to keep the “use current directory” behaviour. Using the current directory can still be achieved by passing `.` as the `library_path` command line argument, regardless of the value set for `ASM_LIBRARY_PATH`.

----

For the record, I have been patching the paths in [the Arch packaging](https://aur.archlinux.org/packages/cvbasic) for a few releases, but it seemed nicer now that there is the `library_path` option to try to send a patch 😺 