### PR TITLE
TI-99/4A Cart Support

### DIFF
--- a/README - TI99.md
+++ b/README - TI99.md
@@ -1,10 +1,7 @@
 The TI99 support is still experimental and in development.
 
 Currently the following demos work:
-test1, happy_face, example, face_joystick, vgm, test2, demo, music, portrait, oscar, space_attack, viboritas, oscar_compressed
-
-The following require bank switching which is not implemented:
-bank
+test1, happy_face, example, face_joystick, vgm, test2, demo, music, portrait, oscar, space_attack, viboritas, oscar_compressed, bank
 
 The current build creates an assembly language file intended to be assembled with xas99 from the xdt99 tool suite: 
 https://github.com/endlos99/xdt99
@@ -15,33 +12,45 @@ The target is a stock TI-99/4A system with 32k memory expansion and joysticks. B
 
 The program supports FCTN-= (Alt-= on PC emulation) to reset.
 
-The program is stored in the 24k memory expansion starting at >A000. The 8k RAM block at >2000 is used for variables and stack. (This is significantly more than most projects require.)
+The program is targeted to run from a bank-switched, non-inverted cartridge ROM. A cartridge and boot header is present in every bank to ensure clean resets, and the main program is copied to the 24k RAM bank at >A000 at startup. The 8k RAM block at >2000 is used for variables and stack. (This is significantly more than most projects require.) A further 125 8k ROM banks are available for a total space of 1MB (minus the runtime and the cartridge headers). 
 
     cvbasic --ti994a test2.bas test2.a99
 
 The output of the compiler is an assembly file, it can be assembled like so:
 
-    xas99.py -R test2.a99 -L test2.txt
+    xas99.py -b -R test2.a99 -L test2.txt
 
-Consult the xas99 manual for details, but in short you need the -R switch to define registers for this code. -L provides a listing file if the assembly was successful.
+Consult the xas99 manual for details, but in short you need the -b switch to generate binary output files and -R switch to define registers for this code. The optional -L provides a listing file if the assembly was successful.
 
-The output of xas is an uncompressed object file in Linux text format with an OBJ extension. You can load it directly in Classic99 as an E/A#3 file, and from there you can SAVE as a program image, or pack into a loader cartridge.
+The output of xas is one or more binary object files with a .bin extension. If your program does not use bank switching, there will be a single file. However, if it does, there will be multiple files generated - three for the fixed area and one for each additional bank you used.
 
-To do this:
+For instance, the above program will create "test2.bin" if not banking, or "test2_b0.bin", "test2_b1.bin", "test2_b2.bin", "test2_b3.bin" and "test2_b4.bin" if the program uses two banks above 0. (Note that because 3 banks are reserved for the fixed space, "bank 1" in your program becomes "b3" in the output files).
 
-- Select Cartridge->Apps->Editor/Assembler from the Classic99 menu
-- Press any key to clear the title page
-- Press '2' to Select Editor/Assembler
-- Press '3' to Load and Run
-- Enter the filename. If you stored the file in your DSK1 folder, this might be "DSK1.test2.obj".
-- After the program loads, press enter to finish loading
-- Enter 'START' as the run program name.
+Run the included python program "linkticart.py" to package these files up into a padded ROM file.
 
-You can also build a disk image for Js99er.net (online TI-99/4A emulator):
-
-    xdm99.py -X sssd work.dsk -a test2.obj -f df80
+    linkticart.py test2.bin test2_8.bin     << non-banked
+    linkticart.py test2_b0.bin test2_8.bin  << is banked
     
-For Js99er.net, select the three lines icon and select Editor/Assembler, then select the disk icon and select the work.dsk file. Follow the previous list of instructions to load the program.
+linkticart will automatically detect the other files if the name ends in "0.bin". Note that in both cases it is recommended the name end with "_8.bin". While this is not mandated by emulation, it is a convention that makes it clear what the file type is. If you don't there is a possibility that the letter before the '.bin' will be recognized as another tag and cause loading issues.
 
-TODO:
-- implement cartridge target (plan is a 24k loader cartridge with ROM support - so 24k fixed code space, 8k pages, and 8k RAM.)
+You can also pass a name for the cartridge for the selection screen, up to 20 characters long (uppercase ASCII only):
+
+    linkticart.py test2.bin test2_8.bin "TEST2"
+
+The resulting cartridge can be used directly on Classic99 and js99er. For MAME, it is necessary to create an "RPK" image. This is a zip file containing the ROM and a 'layout.xml'. The layout.xml contents are below (update with the correct romimage filename). Pack both files into a zip and rename from .zip to .rpk and it should work in MAME.
+
+---------
+<?xml version="1.0" encoding="utf-8"?>
+<romset version="1.0">
+   <resources>
+      <rom id="romimage" file="test2_8.bin"/>
+   </resources>
+   <configuration>
+      <pcb type="paged378">
+         <socket id="rom_socket" uses="romimage"/>
+      </pcb>
+   </configuration>
+</romset>
+---------
+
+The programs will no longer work from disk. If you have a need for that, let me know, we can add a configuration switch, but it is much more limited.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 CVBasic is a BASIC language cross-compiler with a syntax alike to QBasic originally written for the Colecovision video game console.
 
-The CVBasic compiler can create programs up to 1 MB using the BANK statements (using 16K bank switching). 
+The CVBasic compiler can create programs up to 1 MB using the BANK statements (using 16K bank switching on most platforms, 8k on TI-99/4A). 
 
 Later it was extended to support the following platforms:
 
@@ -131,12 +131,12 @@ Using CVBasic to compile a Casio PV-2000 program:
 Using CVBasic to compile a Texas Instruments TI-99/4A program:
 
     cvbasic --ti994a game.bas game.a99
-    xas99.py -R game.a99
-    xdm99.py -X sssd game.dsk -a game.obj -f df80
+    xas99.py -b -R game.a99
+    linkticart.py game.bin game_8.bin "CARTNAME"
     
-You require the utilities from the xdt99 tool suite: [https://github.com/endlos99/xdt99](https://github.com/endlos99/xdt99)
+You require Python3 and the utilities from the xdt99 tool suite: [https://github.com/endlos99/xdt99](https://github.com/endlos99/xdt99)
     
-The target is a stock TI-99/4A system with 32k memory expansion and joysticks. You can execute the dsk or obj file directly with the onlne emulator [js99er.net](js99er.net), or put it the obj file into a DSK directory for Classic99.
+The target is a stock TI-99/4A system with 32k memory expansion and joysticks. The cartridge binary can be used directly with the online emulator [js99er.net](js99er.net) or Classic99, and can be packed into an RPK for MAME (see README - TI99.md).
 
 ### Notes
 
@@ -165,7 +165,7 @@ The Casio PV-2000 can only use binaries up to 16 kb, the keyboard and joystick a
 
 The Creativision can only use binaries up to 32 kb, the joysticks are controller 1 and controller 2, and it can emulate the Coleocovision keypad (CONT1.KEY only) using the keys 0-9, Left and RETN.
 
-The TI-99/4A can only generate binaries up to 24 kb. Both joysticks are supported with a single button. The second button is simulated on the keyboard with control for player 1 and fctn for player 2. CONT1.KEY will also return uppercase ASCII characters from the keyboard in addition to the stock 0-9, #, * for compatibility with Coleco programs. No keypad is implemented for controller 2 - only the joystick. The program supports FCTN-= (Alt-= on PC emulation) to reset.
+The TI-99/4A can only generate non-banked binaries up to 24 kb. When banking, the fixed space is 24k and pages are 8k. Both joysticks are supported with a single button. The second button is simulated on the keyboard with control for player 1 and fctn for player 2. CONT1.KEY will also return uppercase ASCII characters from the keyboard in addition to the stock 0-9, #, * for compatibility with Coleco programs. No keypad is implemented for controller 2 - only the joystick. The program supports FCTN-= (Alt-= on PC emulation) to reset.
 
 Many people is developing games using CVBasic, feel free to check some of these examples at the [AtariAge Colecovision Programming forum](https://forums.atariage.com/forum/55-colecovision-programming/)
 

--- a/cvbasic.c
+++ b/cvbasic.c
@@ -293,7 +293,6 @@ void emit_warning(char *string)
  */
 void bank_finish(void)
 {
-    /* TODO: not implemented for TI99 yet */
     if (machine == SG1000) {
         if (bank_current == 0) {
             fprintf(output, "BANK_0_FREE:\tEQU $3fff-$\n");
@@ -312,6 +311,22 @@ void bank_finish(void)
             fprintf(output, "\tTIMES $bfff-$ DB $ff\n");
         }
         fprintf(output, "\tDB $%02x\n", bank_current);
+    } else if (machine == TI994A) {
+        if (bank_current == 0) {
+            // bank 0 is copied to RAM so is 24k
+            fprintf(output, "BANK_0_FREE:\tEQU >fffe-$\n");
+            fprintf(output, "\t.rept >fffe-$\n");
+            fprintf(output, "\tbyte 255\n");
+            fprintf(output, "\t.endr\n");
+        } else {
+            // other banks are only 8k
+            fprintf(output, "BANK_%d_FREE:\tEQU >7ffe-$\n", bank_current);
+            fprintf(output, "\t.rept >7ffe-$\n");
+            fprintf(output, "\tbyte 255\n");
+            fprintf(output, "\t.endr\n");
+        }
+        // output the bank switch address so it doesn't need to be calcuated later
+        fprintf(output, "\tdata >%04x\n", (bank_current+2)*2+0x6000);
     } else {
         int c;
         
@@ -4971,13 +4986,14 @@ void compile_statement(int check_for_else)
                     if (lex != C_NUM) {
                         emit_error("Bad syntax for BANK ROM");
                     } else if (value != 128 && value != 256 && value != 512 && value != 1024) {
+                        // TODO: TI can do 2MB as it stands, and 32MB with the scheme. But leaving at 1MB for now.
                         emit_error("BANK ROM not 128, 256, 512 or 1024");
                         get_lex();
                     } else if (bank_switching != 0) {
                         emit_error("BANK ROM used twice");
                         get_lex();
                     } else {
-                        if (machine == SVI || machine == SORD || machine == MEMOTECH || machine == CREATIVISION || machine == EINSTEIN || machine == PV2000 || machine == TI994A) {
+                        if (machine == SVI || machine == SORD || machine == MEMOTECH || machine == CREATIVISION || machine == EINSTEIN || machine == PV2000) {
                             emit_error("Bank-switching not supported with current platform");
                         } else {
                             bank_switching = 1;
@@ -5002,35 +5018,53 @@ void compile_statement(int check_for_else)
                     if (bank_switching == 0) {
                         emit_error("Using BANK SELECT without BANK ROM");
                     } else {
-                        if (machine == COLECOVISION || machine == COLECOVISION_SGM)
-                            c--;
-                        if (bank_rom_size == 128)
-                            c &= 0x07;
-                        else if (bank_rom_size == 256)
-                            c &= 0x0f;
-                        else if (bank_rom_size == 512)
-                            c &= 0x1f;
-                        else
-                            c &= 0x3f;
-                        if (machine == SG1000) {
-                            sprintf(temp, "%d", c & 0x3f);
-                            cpuz80_2op("LD", "A", temp);
-                            cpuz80_2op("LD", "($fffe)", "A");
-                        } else if (machine == MSX) {
-                            sprintf(temp, "%d", c & 0x3f);
-                            cpuz80_2op("LD", "A", temp);
-                            cpuz80_2op("LD", "($7000)", "A");
-                        } else {
+                        if (machine == TI994A) {
+                            // the TI needs to use 8k banks, so our masks are different
+                            c+=2;   // reserving 3 banks (0,1,2) for 'fixed' space
+
                             if (bank_rom_size == 128)
-                                c |= 0xfff8;
+                                c &= 0x0f;
                             else if (bank_rom_size == 256)
-                                c |= 0xfff0;
+                                c &= 0x1f;
                             else if (bank_rom_size == 512)
-                                c |= 0xffe0;
+                                c &= 0x3f;
                             else
-                                c |= 0xffc0;
-                            sprintf(temp, "($%04x)", c);
-                            cpuz80_2op("LD", "A", temp);
+                                c &= 0x7f;
+                            
+                            c = 0x6000+(c*2);   // ROM address to poke
+                            sprintf(temp, "@>%x", c);
+                            cpu9900_1op("clr", temp);
+                        } else {
+                            if (machine == COLECOVISION || machine == COLECOVISION_SGM)
+                                c--;
+                            if (bank_rom_size == 128)
+                                c &= 0x07;
+                            else if (bank_rom_size == 256)
+                                c &= 0x0f;
+                            else if (bank_rom_size == 512)
+                                c &= 0x1f;
+                            else
+                                c &= 0x3f;
+                            if (machine == SG1000) {
+                                sprintf(temp, "%d", c & 0x3f);
+                                cpuz80_2op("LD", "A", temp);
+                                cpuz80_2op("LD", "($fffe)", "A");
+                            } else if (machine == MSX) {
+                                sprintf(temp, "%d", c & 0x3f);
+                                cpuz80_2op("LD", "A", temp);
+                                cpuz80_2op("LD", "($7000)", "A");
+                            } else {
+                                if (bank_rom_size == 128)
+                                    c |= 0xfff8;
+                                else if (bank_rom_size == 256)
+                                    c |= 0xfff0;
+                                else if (bank_rom_size == 512)
+                                    c |= 0xffe0;
+                                else
+                                    c |= 0xffc0;
+                                sprintf(temp, "($%04x)", c);
+                                cpuz80_2op("LD", "A", temp);
+                            }
                         }
                     }
                 } else {
@@ -5050,28 +5084,49 @@ void compile_statement(int check_for_else)
                         emit_error("Using BANK without BANK ROM");
                     } else {
                         d = c;
-                        if (machine == COLECOVISION || machine == COLECOVISION_SGM)
-                            c--;
-                        if (bank_rom_size == 128)
-                            c &= 0x07;
-                        else if (bank_rom_size == 256)
-                            c &= 0x0f;
-                        else if (bank_rom_size == 512)
-                            c &= 0x1f;
-                        else
-                            c &= 0x3f;
-                        bank_finish();
-                        sprintf(temp, "$%05x", c << 14);
-                        cpuz80_1op("FORG", temp);
-                        if (machine == SG1000) {
-                            cpuz80_1op("ORG", "$4000");
-                        } else if (machine == MSX) {
-                            cpuz80_1op("ORG", "$8000");
+                        if (machine == TI994A) {
+                            // the TI needs to use 8k banks, so our masks are different
+                            c+=2;   // reserving 3 banks (0,1,2) for 'fixed' space
+
+                            if (bank_rom_size == 128)
+                                c &= 0x0f;
+                            else if (bank_rom_size == 256)
+                                c &= 0x1f;
+                            else if (bank_rom_size == 512)
+                                c &= 0x3f;
+                            else
+                                c &= 0x7f;
+                            bank_finish();
+                            
+                            sprintf(temp, "%d", c);
+                            cpu9900_1op("bank", temp);
+                            cpu9900_empty();
                         } else {
-                            cpuz80_1op("ORG", "$c000");
+                            if (machine == COLECOVISION || machine == COLECOVISION_SGM)
+                                c--;
+                            if (machine == TI994A)
+                                c+=2;   // reserving 3 banks (0,1,2) for 'fixed' space
+                            if (bank_rom_size == 128)
+                                c &= 0x07;
+                            else if (bank_rom_size == 256)
+                                c &= 0x0f;
+                            else if (bank_rom_size == 512)
+                                c &= 0x1f;
+                            else
+                                c &= 0x3f;
+                            bank_finish();
+                            sprintf(temp, "$%05x", c << 14);
+                            cpuz80_1op("FORG", temp);
+                            if (machine == SG1000) {
+                                cpuz80_1op("ORG", "$4000");
+                            } else if (machine == MSX) {
+                                cpuz80_1op("ORG", "$8000");
+                            } else {
+                                cpuz80_1op("ORG", "$c000");
+                            }
+                            cpuz80_empty();
                         }
                         bank_current = d;
-                        cpuz80_empty();
                     }
                 }
             } else if (strcmp(name, "VDP") == 0 && lex_sneak_peek() == '(') {   /* VDP pseudo-array */
@@ -5620,7 +5675,9 @@ int main(int argc, char *argv[])
         fprintf(output, "STACK:\tequ %C%04x\t; Base stack pointer\n", hex, consoles[machine].stack);
     fprintf(output, "VDP:\tequ %c%02x\t; VDP port (write)\n", hex, consoles[machine].vdp_port_write);
     fprintf(output, "VDPR:\tequ %c%02x\t; VDP port (read)\n", hex, consoles[machine].vdp_port_read);
-    fprintf(output, "PSG:\tequ %c%02x\t; PSG port (write)\n", hex, consoles[machine].psg_port);
+    if (machine != TI994A) {
+        fprintf(output, "PSG:\tequ %c%02x\t; PSG port (write)\n", hex, consoles[machine].psg_port);
+    }
     if (machine == CREATIVISION) {
         fprintf(output, "SMALL_ROM:\tequ %d\n", small_rom);
     }
@@ -5630,8 +5687,7 @@ int main(int argc, char *argv[])
         if (machine == COLECOVISION || machine == COLECOVISION_SGM) {
             fprintf(output, "\tforg $%05x\n", bank_rom_size * 0x0400 - 0x4000);
         } else if (machine == TI994A) {
-            /* not implemented yet anyway... */
-            fprintf(output, "\taorg >6000\n");
+            /* nothing to output here - it's all in the prologue */
         } else {
             fprintf(output, "\tforg $00000\n");
         }

--- a/cvbasic_9900_epilogue.asm
+++ b/cvbasic_9900_epilogue.asm
@@ -3,12 +3,12 @@ SLAST
 ;;; CV BASIC Epilogue
 
 ; data in low RAM
-    aorg >2000
+    dorg >2000
 
 ; must be even aligned
 ; mirror for sprite table
 sprites	    bss 128
 
 ; Vars can start at >2080
-    aorg >2080
+    dorg >2080
 

--- a/linkticart.py
+++ b/linkticart.py
@@ -1,0 +1,98 @@
+#!/usr/bin/python
+
+import os.path
+import sys
+
+# converts a binary from xas99 (xas99.py -b -R file.a99) with banks to a single non-inverted cart image
+# note: minimal error checking - GIGO.
+# pass the name of the first file (ie: file_b0.bin)
+if (len(sys.argv) < 3):
+    print('Pass the first output file (ie: file_b0.bin), and the output file, and optionally a name for the cart')
+    print('ie: linkticart.py file_b0.bin file_8.bin "AWESOME GAME"')
+    exit(1)
+
+f = open(sys.argv[1], 'rb')
+data = f.read()
+f.close()
+
+# first 80 bytes are the cartridge header
+hdr = data[0:80]
+
+if (len(sys.argv) > 3):
+    name = sys.argv[3].upper()
+    while (len(name)<20):
+        name += ' '
+    p = hdr.find(b'CVBASIC GAME        *')
+    if p == -1:
+        print('WARNING: Could not find cart name to set it')
+    else:
+        hdr = hdr[0:p] + bytearray(name, 'utf-8') + hdr[p+20:]
+
+# after 16k starts the RAM data
+ram = data[16384:]
+
+# make sure we have 3 pages to pull from (especially if not banked, it won't be padded)
+while len(ram) < 8192*3:
+    ram += b'\xff'*8192
+
+fo = open(sys.argv[2], 'wb')
+
+# write the loader pages
+fo.write(hdr)
+fo.write(ram[0:8112])
+fo.write(hdr)
+fo.write(ram[8112:16224])
+fo.write(hdr)
+fo.write(ram[16224:24336])
+# any excess is discarded
+
+# now check if there are any pages to concatenate
+# track pages written so we can square up the final size
+sz = 3
+
+if (sys.argv[1][-5:] != '0.bin'):
+    print('Banking not detected - finishing cart...')
+else:
+    print('Banked cart detected...')
+
+    namebase = sys.argv[1][:-5]
+
+    file = namebase + str(sz) + '.bin'
+
+    while os.path.isfile(file):
+        f = open(file, 'rb')
+        data = f.read()
+        f.close()
+        fo.write(data)
+        sz+=1
+        file = namebase + str(sz) + '.bin'
+
+desired=0
+if sz>64:
+    desired=128
+elif sz>32:
+    desired=64
+elif sz>16:
+    desired=32
+elif sz>8:
+    desired=16
+elif sz>4:
+    desired=8
+else:
+    desired=4
+
+while sz<desired:
+    sz+=1
+    fo.write(hdr)
+    fo.write(b'\xff'*8112)
+
+fo.close()
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
- replaced TI build with banked cartridge - all builds now load from cartridge instead of disk
- added linkticart.py script to link the output file(s)
- updated documentation
- removed some TI irrelevant equates from the output
- changed the variable/data aorgs to dorgs so xas99 knows they aren't meant to be output