### PR TITLE
Fixes for TI keyboard scan and VDP()

### DIFF
--- a/cvbasic.c
+++ b/cvbasic.c
@@ -5172,8 +5172,8 @@ void compile_statement(int check_for_else)
                     /* Simpler to do inline */
                     sprintf(temp, "%d   ; %d*256+0x8000", vdp_reg*256+0x8000, vdp_reg);
                     cpu9900_2op("li", "r1", temp);
-                    cpu9900_2op("movb", "r1", "@VDPWADR");
                     cpu9900_2op("movb", "r0", "@VDPWADR");
+                    cpu9900_2op("movb", "r1", "@VDPWADR");
                     /*
                      ** only timing critical in scratchpad with register indirect addressing,
                      ** even then probably safe on the 99/4A

--- a/cvbasic_9900_prologue.asm
+++ b/cvbasic_9900_prologue.asm
@@ -905,7 +905,7 @@ int_handler
     jeq -!key2      ; we don't have a jump if not negative
     
     ai r11,>0100
-    ci r11,>0700
+    ci r11,>0600
     jne -!key1
     
     li r11,>0f00

--- a/examples/controller.bas
+++ b/examples/controller.bas
@@ -100,10 +100,10 @@ main_loop:
 				x = ((c - 1) % 3) * 16
 				y = 63 + ((c - 1) / 3) * 16
 				c = c + 48
-            ELSE
-                rem some systems have extra characters
-                x = 16
-                y = 127
+			ELSE
+				rem some systems have extra characters
+				x = 16
+				y = 127
 			END IF
 			SPRITE 6, left_y + y, left_x + x, c, 9
 		END IF
@@ -154,14 +154,14 @@ main_loop:
 				x = 32
 				y = 111
 				c = 35
-            ELSEIF c > 0 AND c < 10 THEN
+			ELSEIF c > 0 AND c < 10 THEN
 				x = ((c - 1) % 3) * 16
 				y = 63 + ((c - 1) / 3) * 16 
 				c = c + 48 
-            ELSE
-                rem some systems have extra characters
-                x = 16
-                y = 127
+			ELSE
+				rem some systems have extra characters
+				x = 16
+				y = 127
 			END IF
 			SPRITE 14, right_y + y, right_x + x, c, 9
 		END IF

--- a/examples/controller.bas
+++ b/examples/controller.bas
@@ -96,10 +96,14 @@ main_loop:
 				x = 32
 				y = 111
 				c = 43
-			ELSE
+			ELSEIF c > 0 AND c < 10 THEN
 				x = ((c - 1) % 3) * 16
 				y = 63 + ((c - 1) / 3) * 16
-				c = c + 48 
+				c = c + 48
+            ELSE
+                rem some systems have extra characters
+                x = 16
+                y = 127
 			END IF
 			SPRITE 6, left_y + y, left_x + x, c, 9
 		END IF
@@ -150,10 +154,14 @@ main_loop:
 				x = 32
 				y = 111
 				c = 35
-			ELSE
+            ELSEIF c > 0 AND c < 10 THEN
 				x = ((c - 1) % 3) * 16
 				y = 63 + ((c - 1) / 3) * 16 
 				c = c + 48 
+            ELSE
+                rem some systems have extra characters
+                x = 16
+                y = 127
 			END IF
 			SPRITE 14, right_y + y, right_x + x, c, 9
 		END IF

--- a/linkticart.py
+++ b/linkticart.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import os.path
 import sys


### PR DESCRIPTION
Found a couple of issues while testing controller.bas

- patch controller.bas example to recognize inputs outside of the coleco controller (ie: letters)
- fix 9900 prologue - keyboard read was scanning one bit too many, causing the joystick to conflict with keys
- fix VDP() pseudo-array - was writing VDP bytes in the wrong order
- make shebang on linkticart.py more compatible
