### PR TITLE
Added support for multiple passed-in constants. eg. cvbasic -DMYCONST=123 ...

### DIFF
--- a/cvbasic.c
+++ b/cvbasic.c
@@ -6078,7 +6078,11 @@ int main(int argc, char *argv[])
             exit(2);
         }
     }
-    if (argv[c][0] == '-' && argv[c][1] == 'D') {
+
+     /*
+      ** passed-in constants
+      */
+    while (argv[c][0] == '-' && argv[c][1] == 'D') {
         int i = 1;
         char ch = 0;
         struct constant *d = NULL;
@@ -6095,11 +6099,12 @@ int main(int argc, char *argv[])
             }
         }
         if (d == NULL) {
-            fprintf(stderr, "%s missing assignment. Syntax: -DMYCONSTANT=123\n", argv[c]);
+            fprintf(stderr, "%s missing assignment. Syntax: -DMYCONSTANT=123 -D#MYBIGCONSTANT=12345\n", argv[c]);
             exit(2);
         }
         c++;
     }
+
     strcpy(current_file, argv[c]);
     err_code = 0;
     input = fopen(current_file, "r");

--- a/cvbasic.c
+++ b/cvbasic.c
@@ -5976,11 +5976,11 @@ int main(int argc, char *argv[])
         machine = COLECOVISION;
         while (machine < TOTAL_TARGETS) {
             if (machine == COLECOVISION)
-                fprintf(stderr, "    cvbasic input.bas output.asm [library_path]\n");
+                fprintf(stderr, "    cvbasic [-DMYCONST=123] input.bas output.asm [library_path]\n");
             else
-                fprintf(stderr, "    cvbasic --%s input.bas output.asm [library_path]\n", consoles[machine].name);
+                fprintf(stderr, "    cvbasic --%s [-DMYCONST=123] input.bas output.asm [library_path]\n", consoles[machine].name);
             if (consoles[machine].options[0])
-                fprintf(stderr, "    cvbasic --%s %s input.bas output.asm [library_path]\n", consoles[machine].name, consoles[machine].options);
+                fprintf(stderr, "    cvbasic --%s %s [-DMYCONST=123] input.bas output.asm [library_path]\n", consoles[machine].name, consoles[machine].options);
             fprintf(stderr, "        %s\n",
                     consoles[machine].description);
             machine++;
@@ -6077,6 +6077,28 @@ int main(int argc, char *argv[])
             fprintf(stderr, "-rom16 option only applies to Creativision.\n");
             exit(2);
         }
+    }
+    if (argv[c][0] == '-' && argv[c][1] == 'D') {
+        int i = 1;
+        char ch = 0;
+        struct constant *d = NULL;
+        while (ch = argv[c][++i]) {
+            if (!isalnum(ch) && ch != '_' && ch != '#' && ch != '=') {
+                fprintf(stderr, "%s name includes invalid characters.\n", argv[c]);
+                exit(2);
+                }
+            if (ch == '=') {
+                argv[c][i] = '\0';
+                d = constant_add(&argv[c][2]);
+                d->value = atoi(&argv[c][i + 1]);
+                break;
+            }
+        }
+        if (d == NULL) {
+            fprintf(stderr, "%s missing assignment. Syntax: -DMYCONSTANT=123\n", argv[c]);
+            exit(2);
+        }
+        c++;
     }
     strcpy(current_file, argv[c]);
     err_code = 0;

--- a/manual.txt
+++ b/manual.txt
@@ -206,6 +206,11 @@ The following statements are available:
 
      Constants that start with the # prefix are treated as 16-bit numbers, and
      if this isn't present then the constant will be treated as an 8-bit number.
+
+     Constants can be passed-in to CVBasic via the command-line:
+
+       cvbasic -DMYCONST=123 in.bas output.asm
+       cvbasic -D#MYBIGCONST=12345 in.bas output.asm
   
   GOTO label        
   


### PR DESCRIPTION
Previous workaround for this was a wrapper .bas file. Now you can pass constants in directly.

Now you can do this:

```
cvbasic -DMYCONST=123 -D#MYBIGCONST=12345 in.bas output.asm
```

Which is equivalent to having these two lines at the start of in.bas:

```
CONST MYCONST = 123 
CONST #MYBIGCONST = 12345
```

Handy for passing in compile-time flags