### PR TITLE
Fixed CHR$() on TMS9900. Fixed Issue #23

### DIFF
--- a/cvbasic.c
+++ b/cvbasic.c
@@ -3485,7 +3485,6 @@ void compile_statement(int check_for_else)
                                 cpu6502_noop("TAX");
                             } else if (target == CPU_9900) {
                                 cpu9900_2op("mov", "r0", "r2");
-                                cpu9900_1op("swpb", "r2");
                             }
                             generic_call("print_char");
                         } else {

--- a/cvbasic_9900_prologue.asm
+++ b/cvbasic_9900_prologue.asm
@@ -416,13 +416,16 @@ print_digit
     ci r5,>0200
     jl !6
     mov r5,r2
-    jne print_char
+    jne print_char2
 !6
     li r2,>30
 !3
     andi r5,>00ff
     ori r5,>0100
-print_char
+    jmp print_char2
+print_char1
+    mov r11,r6
+print_char2
     mov @cursor,r0      ; get cursor
     andi r0,>07ff       ; enforce position - large range for two screen pages
     ai r0,>1800         ; add is safer than OR, and we have that option
@@ -431,6 +434,13 @@ print_char
     movb r2,@VDPWDATA
     inc @cursor         ; track it
     b *r6
+print_char
+    mov r11,r4
+    swpb r2
+    limi 0
+    bl @print_char1
+    limi 2
+    b *r4
 
 ; Load sprite definitions: Sprite number in R4, CPU data in R0, count of sprites in R5 (MSB)
 ; Original: pointer = sprite number, temp = CPU address, a = number sprites


### PR DESCRIPTION
Can't re-use original print_char because the return address isn't correct and we want to disable interrupts